### PR TITLE
Making "Image" in "View Image" text all minuscule

### DIFF
--- a/content.js
+++ b/content.js
@@ -46,7 +46,7 @@ function addLinks(node) {
 
             // Add ViewImage button URL
             var viewImageLink = document.createElement('a');
-            viewImageLink.innerHTML = '<span>View Image</span>';
+            viewImageLink.innerHTML = '<span>View image</span>';
             viewImageLink.setAttribute('href', imageURL);
             viewImage.appendChild(viewImageLink);
 


### PR DESCRIPTION
Reason: Original "View image" button has "image" in minuscule, i.e. not "View **I**mage".