### PR TITLE
Use a relative href for searchbyimage

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,7 +28,7 @@ function addLinks(node) {
 
             // Create Search by image button
             var searchByImage = document.createElement('a');
-            searchByImage.setAttribute('href', 'https://www.google.com/searchbyimage?&image_url=' + imageURL);
+            searchByImage.setAttribute('href', '/searchbyimage?&image_url=' + imageURL);
             searchByImage.setAttribute('class', 'ext_addon');
             searchByImage.setAttribute('style', 'margin-left:4pt;');
 


### PR DESCRIPTION
No longer sends people using other Google TLDs to google.com.