### PR TITLE
Basic options setup, option for opening view image in new tab

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -1,0 +1,6 @@
+body {
+    color: #212121;
+    font-family: Roboto, Arial, sans-serif;
+    font-size: 16px;
+    font-weight: 500;
+}

--- a/html/options.html
+++ b/html/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="../css/options.css">
+    </head>
+    <body>
+        Open images in a new tab: <input type="checkbox" id="open-in-new-tab">
+
+        <script src="../js/options.js"></script>
+    </body>
+</html>

--- a/js/background.js
+++ b/js/background.js
@@ -1,0 +1,11 @@
+// Default options
+const defaultOptions = {
+    'open-in-new-tab': false
+};
+
+// Save default options to storage if they don't already exist
+chrome.storage.sync.get('defaultOptions', function(storage) {
+    if (!storage.defaultOptions) {
+        chrome.storage.sync.set({defaultOptions});
+    }
+});

--- a/js/content-script.js
+++ b/js/content-script.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function toI18n(obj, tag) {
     var msg = tag.replace(/__MSG_(\w+)__/g, function(match, v1) {
         return v1 ? chrome.i18n.getMessage(v1) : '';
@@ -57,6 +59,9 @@ function addLinks(node) {
             var viewImageLink = document.createElement('a');
             toI18n(viewImageLink, '<span>__MSG_ViewImage__</span>');
             viewImageLink.setAttribute('href', imageURL);
+            if (options['open-in-new-tab']) {
+                viewImageLink.setAttribute('target', '_blank');
+            }
             viewImage.appendChild(viewImageLink);
 
             // Add ViewImage button to Image Links
@@ -66,20 +71,27 @@ function addLinks(node) {
     }
 }
 
-var observer = new MutationObserver(function (mutations) {
-    mutations.forEach((mutation) => {
-        if (mutation.addedNodes && mutation.addedNodes.length > 0) {
-            for (var i = 0; i < mutation.addedNodes.length; i++) {
-                var newNode = mutation.addedNodes[i];
-                addLinks(newNode);
+
+// Get options and start adding links
+var options;
+chrome.storage.sync.get(['options', 'defaultOptions'], function(storage) {
+    options = Object.assign(storage.defaultOptions, storage.options);
+
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach((mutation) => {
+            if (mutation.addedNodes && mutation.addedNodes.length > 0) {
+                for (var i = 0; i < mutation.addedNodes.length; i++) {
+                    var newNode = mutation.addedNodes[i];
+                    addLinks(newNode);
+                }
             }
-        }
+        });
     });
-});
 
-observer.observe(document.body, {
-    childList: true,
-    subtree: true
-});
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    });
 
-addLinks(document.body);
+    addLinks(document.body);
+});

--- a/js/options.js
+++ b/js/options.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Current options extend defaults
+let defaultOptions;
+let options;
+
+// Load options from storage
+const load = function() {
+    return new Promise(function(resolve) {
+        chrome.storage.sync.get('options', function(storage) {
+            // Get and save options
+            options = storage.options || defaultOptions;
+
+            // Show and resolve
+            show(options);
+            resolve(options);
+        });
+    });
+};
+
+// Save options to storage
+const save = function(object) {
+    return new Promise(function(resolve) {
+        chrome.storage.sync.set({
+            'options': object
+        }, resolve);
+    });
+};
+
+// Show options
+const show = function(options) {
+    for (const key in options) {
+        if (options.hasOwnProperty(key)) {
+            document.getElementById(key).checked = options[key];
+        }
+    }
+};
+
+// Reset to defaults
+// TODO: attach to reset button
+const reset = function() {
+    save(defaultOptions)
+        .then(() => show(defaultOptions));
+};
+
+
+// Load default options once when page loads, then load user options
+chrome.storage.sync.get('defaultOptions', function(storage) {
+    // Get and save default options
+    defaultOptions = storage.defaultOptions;
+
+    // Load options
+    load();
+});
+
+// On change, save
+document.addEventListener('input', event => {
+    options[event.target.id] = event.target.checked;
+    save(options);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -10,10 +10,27 @@
         "16": "icon/16.png"
     },
     "author": "Joshua Butt",
+    "applications": {
+        "gecko": {
+            "id": "{287dcf75-bec6-4eec-b4f6-71948a2eea29}"
+        }
+    },
+    "permissions": [
+        "storage"
+    ],
+    "options_ui": {
+        "page": "html/options.html"
+    },
+    "background": {
+        "persistent": false,
+        "scripts": [
+            "js/background.js"
+        ]
+    },
     "content_scripts": [
         {
             "js": [
-                "content.js"
+                "js/content-script.js"
             ],
             "matches": [
                 "*://*.google.com/search?*tbm=isch*",


### PR DESCRIPTION
Added basic options and background page. The background page sets the defaults and the options page and content script query from chrome.storage.

View image in a new tab is also implemented as a proof of concept.