### PR TITLE
Add reset button to options, fix bug re: binding to default options

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -1,6 +1,11 @@
 body {
+    min-width: 200px;
+    min-height: 200px;
     color: #212121;
     font-family: Roboto, Arial, sans-serif;
     font-size: 16px;
-    font-weight: 500;
+}
+
+#reset {
+    margin-top: 24px;
 }

--- a/html/options.html
+++ b/html/options.html
@@ -7,6 +7,11 @@
     <body>
         Open images in a new tab: <input type="checkbox" id="open-in-new-tab">
 
+
+        <div>
+            <button id="reset">Reset to defaults</button>
+        </div>
+
         <script src="../js/options.js"></script>
     </body>
 </html>

--- a/js/options.js
+++ b/js/options.js
@@ -9,7 +9,7 @@ const load = function() {
     return new Promise(function(resolve) {
         chrome.storage.sync.get('options', function(storage) {
             // Get and save options
-            options = storage.options || defaultOptions;
+            options = storage.options || Object.assign({}, defaultOptions);
 
             // Show and resolve
             show(options);
@@ -37,11 +37,11 @@ const show = function(options) {
 };
 
 // Reset to defaults
-// TODO: attach to reset button
 const reset = function() {
     save(defaultOptions)
         .then(() => show(defaultOptions));
 };
+document.getElementById('reset').addEventListener('click', reset);
 
 
 // Load default options once when page loads, then load user options


### PR DESCRIPTION
I added a reset to defaults button in the options with the code I already had. This also will fix the failing state of the linter for the chrome branch as well as the other active PRs.