### PR TITLE
Turkish translation [correction]

### DIFF
--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -24,7 +24,7 @@
         "description": "Sıfırlama düğmesidir."
     },
     "optionsButton": {
-        "message": "seçenekleri",
+        "message": "Seçenekler",
         "description": "Text displayed on the link to options button."
     },
     "donatePayPal": {


### PR DESCRIPTION
seçenekleri --> Seçenekler

(I don't speak Turkish.)
I corrected based on "Issue: Mistranslation #89".