### PR TITLE
Updated node.closest and fetching image from URL

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -41,7 +41,7 @@ function addLinks(node) {
         if (thumbnail === null) {
             // If no thumbnail found, try getting image from URL
             var url = new URL(window.location);
-            var imgLink = url.searchParams.get("imgurl");
+            var imgLink = url.searchParams.get('imgurl');
             if (imgLink) {
                 image = new Object();
                 image.src = imgLink;

--- a/js/content-script.js
+++ b/js/content-script.js
@@ -42,8 +42,8 @@ function addLinks(node) {
             // If no thumbnail found, try getting image from URL
             var query = window.location.search.substring(1);
             var vars = query.split('&');
-            for (var i = 0; i < vars.length; i++) {
-                var pair = vars[i].split('=');
+            for (var k = 0; k < vars.length; k++) {
+                var pair = vars[k].split('=');
                 if (decodeURIComponent(pair[0]) == 'imgurl') {
                     image = new Object();
                     image.src = decodeURIComponent(pair[1]);

--- a/js/content-script.js
+++ b/js/content-script.js
@@ -38,12 +38,29 @@ function addLinks(node) {
     // Override url for images using base64 embeds
     if (image === null || image.src === '' || image.src.startsWith('data')) {
         var thumbnail = document.querySelector('img[name="' + object.dataset.itemId + '"]');
-        var meta = thumbnail.closest('.rg_bx').querySelector('.rg_meta');
+        if (thumbnail === null) {
+            // If no thumbnail found, try getting image from URL
+            var query = window.location.search.substring(1);
+            var vars = query.split('&');
+            for (var i = 0; i < vars.length; i++) {
+                var pair = vars[i].split('=');
+                if (decodeURIComponent(pair[0]) == 'imgurl') {
+                    image = new Object();
+                    image.src = decodeURIComponent(pair[1]);
+                }
+            }
+        } else {
+            var meta = thumbnail.closest('.rg_bx').querySelector('.rg_meta');
 
-        var metadata = JSON.parse(meta.innerHTML);
+            var metadata = JSON.parse(meta.innerHTML);
 
-        image = new Object();
-        image.src = metadata.ou;
+            image = new Object();
+            image.src = metadata.ou;
+        }
+
+        // Supress error in console
+        if (image === null)
+            return;
     }
 
     // Create more sizes button

--- a/js/content-script.js
+++ b/js/content-script.js
@@ -14,7 +14,7 @@ function localiseObject(obj, tag) {
 
 
 function addLinks(node) {
-    var object = node.closest('.irc_c[style*="visibility: visible;"]');
+    var object = node.closest('.irc_c[style*="visibility: visible;"], .irc_c[style*="transform: translate3d(0px, 0px, 0px);"]');
 
     // Stop if object not found
     if (object === null) {
@@ -40,14 +40,11 @@ function addLinks(node) {
         var thumbnail = document.querySelector('img[name="' + object.dataset.itemId + '"]');
         if (thumbnail === null) {
             // If no thumbnail found, try getting image from URL
-            var query = window.location.search.substring(1);
-            var vars = query.split('&');
-            for (var k = 0; k < vars.length; k++) {
-                var pair = vars[k].split('=');
-                if (decodeURIComponent(pair[0]) == 'imgurl') {
-                    image = new Object();
-                    image.src = decodeURIComponent(pair[1]);
-                }
+            var url = new URL(window.location);
+            var imgLink = url.searchParams.get("imgurl");
+            if (imgLink) {
+                image = new Object();
+                image.src = imgLink;
             }
         } else {
             var meta = thumbnail.closest('.rg_bx').querySelector('.rg_meta');

--- a/js/options.js
+++ b/js/options.js
@@ -78,7 +78,7 @@ chrome.storage.sync.get('defaultOptions', function (storage) {
 });
 
 // On change, save
-document.addEventListener('input', event => {
+document.addEventListener('change', event => {
     switch (event.target.type) {
     case ('checkbox'): {
         options[event.target.id] = event.target.checked;


### PR DESCRIPTION
**Fix for embedded image:**
If `image` and `thumbnail` are null and we are in embedded search, try getting image link from URL.

**Fix for standard image:**
When switching image preview, Google doesn't always set style `visibility: visible`. Search for style `transform: translate3d(0px, 0px, 0px)` fixes that.

Should fix #99. Needs testing