### PR TITLE
Ignore thumbnails from gstatic.com

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -33,7 +33,7 @@ function addLinks(node) {
     var imageText = object.querySelector('._cjj > .irc_it > .irc_hd > ._r3');
 
     // Retrive the image;
-    var image = object.querySelector('img[alt^="Image result"][src].irc_mut, img[src].irc_mi');
+    var image = object.querySelector('img[alt^="Image result"][src]:not([src^="https://encrypted-tbn"]).irc_mut, img[src].irc_mi');
 
     // Override url for images using base64 embeds
     if (image === null || image.src === '' || image.src.startsWith('data')) {


### PR DESCRIPTION
Even after my last PR, we still sometimes select `img` with URL `...encrypted-tbn*.gstatic.com...`.

This can be solved either by changing selector or by checking src with regex afterwards. Regex would probably be safer because Google has multiple URLs `...-tbn[0-3]...`. However, the selector is much less resource hungry.

Surprisingly enough removing the first part of the selector seems to fix this issue as well. I'm however not sure what else get's broken instead.
Would you @bijij consider adding more descriptive comments for those querySelectors?