### PR TITLE
Text vertical alignment fix

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -52,7 +52,10 @@ button {
 
 #about {
     padding: 16px;
-    
+}
+
+button>img {
+  vertical-align: middle;
 }
 
 button:active {

--- a/html/popup.html
+++ b/html/popup.html
@@ -16,13 +16,13 @@
         <div class="center">
             <a href="#" id="options-page">
                 <button type="button">
-                    <img src="../img/options.png" height="15px" style="position: relative; top: 2px;" />
+                    <img src="../img/options.png" height="15px"/>
                     <span data-localise="__MSG_optionsButton__">&nbsp;Options</span>
                 </button>
             </a>
             <a href="https://github.com/bijij/ViewImage" target="_blank">
                 <button type="button">
-                    <img src="../img/github.png" height="15px" style="position: relative; top: 2px;" />
+                    <img src="../img/github.png" height="15px"/>
                     <span>&nbsp;Github</span>
                 </button>
             </a>
@@ -38,7 +38,7 @@
         <br>
         <a href="https://goo.gl/Kxyaq8" target="_blank">
             <button type="button">
-                <img src="../img/paypal.png" height="15px" style="position: relative; top: 2px;" />
+                <img src="../img/paypal.png" height="15px"/>
                 <span data-localise="__MSG_donatePayPal__">&nbsp;Donate via Paypal</span>
             </button>
         </a>


### PR DESCRIPTION
Just a minor visual tweak on the popop's buttons for a better vertical alignment. Tested on Firefox 58.0.1 & 59.0.1 

| Before | After |
| -- | -- |
|  <img width="231" alt="final - before" src="https://user-images.githubusercontent.com/6209647/37568873-6c89a844-2adb-11e8-8d81-9db61a1fa7e8.png"> | <img width="203" alt="final - after" src="https://user-images.githubusercontent.com/6209647/37568872-6c6cbfc2-2adb-11e8-95b2-5e497fe302d6.png"> |
