### PR TITLE
Minor tweaks on options layout

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -2,9 +2,9 @@ body {
     color: #212121;
     font-family: Roboto, Arial, sans-serif;
     font-size: 16px;
-	
+
 	background-color: #fafafa;
-	width: 320px;
+	width: 600px;
 }
 
 a {
@@ -93,11 +93,11 @@ button:active {
 }
 
 .textbox {
-	margin: 0 1em 0 2em;
+	margin: 5px 0px 0 20px;
 }
 
 input[type="text"] {
-	width: 100%;
+	float:right;
 	border: none;
 	outline: none;
 	padding: 4px;

--- a/html/options.html
+++ b/html/options.html
@@ -52,12 +52,11 @@
     </div>
 
     <div class="textbox" id="manual-toggle">
-        <span data-localise="__MSG_viewImage__">View Image:</span>
-        <br>
+        <span data-localise="__MSG_viewImage__">View Image: </span>
         <input type="text" id="button-text-view-image" />
         <br>
-        <span data-localise="__MSG_searchImg__">Search by Image:</span>
         <br>
+        <span data-localise="__MSG_searchImg__">Search by Image: </span>
         <input type="text" id="button-text-search-by-image" />
     </div>
 


### PR DESCRIPTION
Hello,
just another minor fix for the layout. Before it was a bit confusing where an option starts and where it finishes.

Tested on Firefox 59.0.1

| Before | After |
| -- | -- |
| <img width="584" alt="before - final" src="https://user-images.githubusercontent.com/6209647/37607299-f451f166-2b97-11e8-9345-c6f991a3e127.png"> | <img width="711" alt="after - final" src="https://user-images.githubusercontent.com/6209647/37607297-f42f68e4-2b97-11e8-89fc-af8397a411e9.png"> |
