### PR TITLE
Corrected subect to subject

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -38,8 +38,8 @@
 
     <div class="toggle">
         <span data-localise="__MSG_settingsToggle_subjectCopyright__">Hide "Images may be subject to Copyright" warning:</span>
-        <input type="checkbox" id="hide-images-subect-to-copyright" />
-        <label for="hide-images-subect-to-copyright"></label>
+        <input type="checkbox" id="hide-images-subject-to-copyright" />
+        <label for="hide-images-subject-to-copyright"></label>
     </div>
 
     <br>

--- a/js/background.js
+++ b/js/background.js
@@ -3,7 +3,7 @@ const defaultOptions = {
     'open-in-new-tab': true,
     'open-search-by-in-new-tab': true,
     'show-globe-icon': true,
-    'hide-images-subect-to-copyright': false,
+    'hide-images-subject-to-copyright': false,
     'manually-set-button-text': false,
     'button-text-view-image': '',
     'button-text-search-by-image': '',

--- a/js/content-script.js
+++ b/js/content-script.js
@@ -120,7 +120,7 @@ function addLinks(node) {
     }
 
     // hide copyright text if toggle enabled 
-    if (options['hide-images-subect-to-copyright']) {
+    if (options['hide-images-subject-to-copyright']) {
         var copyWarning = object.querySelector('.irc_bimg.irc_it');
         copyWarning.style = 'display: none;';
     }


### PR DESCRIPTION
I found in several files that "hide-images-subject-to-copyright" was written as "hide-images-subect-to-copyright." These commits correct the typo.