### PR TITLE
Fix for recent Google/Chrome changes

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -114,7 +114,7 @@ function addLinks(node) {
     if (options['show-globe-icon']) {
         var globeIcon = document.querySelector('._RKw._wtf._Ptf');
         if (!globeIcon)
-            globeIcon = document.querySelector('.RL3J9c.Cws1Yc.wmCrUb');
+            globeIcon = document.querySelector('.RL3J9c.z1asCe.GYDk8c');
         viewImageLink.appendChild(globeIcon.cloneNode(true));
 
     }


### PR DESCRIPTION
Apparently there's literally just a single selector that needed to be changed. A bit ridiculous. Not sure if any other functionality is broken, I tested the basic set in Chrome and it's working fine, which is good enough for me. Unlike the other PR to fix this issue (#137), I didn't touch file formatting and simply overwrote the broken-but-similar selector '.RL3J9c.Cws1Yc.wmCrUb' with the new working selector '.RL3J9c.z1asCe.GYDk8c'. #137 is a potentially better fix due to preserving the legacy selector (then again it's potentially poorer from a performance standpoint?), I'm only still submitting this PR because I was originally unaware of #137 (I somehow overlooked it when I went through the pending pull requests) and subsequently spent half an hour figuring out how to patch this, so rather than see that effort mostly wasted now that I'm aware of #137, I thought I might as well submit my patch for consideration on the off chance that a simpler solution was preferred since we didn't patch things exactly the same way. Also, hopefully my clearer title will prevent someone else from overlooking a PR and duplicating this work yet again.