### PR TITLE
Tweak options page style

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -5,10 +5,15 @@ body {
 
 	background-color: #fafafa;
 	width: 600px;
+	margin: 16px;
 }
 
 a {
 	text-decoration: none;
+}
+
+.toggle {
+	margin-bottom: 16px;
 }
 
 .toggle > span {
@@ -96,6 +101,10 @@ button:active {
 	margin: 5px 0px 0 20px;
 }
 
+.textbox > div {
+	margin-bottom: 16px;
+}
+
 input[type="text"] {
 	float:right;
 	border: none;
@@ -106,6 +115,5 @@ input[type="text"] {
 }
 
 .disabled {
-	opacity: 0.54;
-	pointer-events: none;
+	display: none;
 }

--- a/html/options.html
+++ b/html/options.html
@@ -15,17 +15,11 @@
         <label for="open-in-new-tab"></label>
     </div>
 
-    <br>
-    <br>
-
     <div class="toggle">
         <span data-localise="__MSG_settingsToggle_newTab_searchByImage__">Open "Search by Image" in a new tab:</span>
         <input type="checkbox" id="open-search-by-in-new-tab" />
         <label for="open-search-by-in-new-tab"></label>
     </div>
-
-    <br>
-    <br>
 
     <div class="toggle">
         <span data-localise="__MSG_settingsToggle_globeIcon__">Show Globe icon in "View Image" button:</span>
@@ -33,18 +27,12 @@
         <label for="show-globe-icon"></label>
     </div>
 
-    <br>
-    <br>
-
     <!-- Depercated for now.
     <div class="toggle">
         <span data-localise="__MSG_settingsToggle_subjectCopyright__">Hide "Images may be subject to Copyright" warning:</span>
         <input type="checkbox" id="hide-images-subject-to-copyright" />
         <label for="hide-images-subject-to-copyright"></label>
     </div>
-
-    <br>
-    <br>
     -->
 
     <div class="toggle">
@@ -54,9 +42,6 @@
         <label for="no-referrer"></label>
     </div>
 
-    <br>
-    <br>
-
     <div class="toggle">
         <span data-localise="__MSG_settingsToggle_buttonText__">Manually set button text:</span>
         <input type="checkbox" id="manually-set-button-text" />
@@ -64,15 +49,16 @@
     </div>
 
     <div class="textbox" id="manual-toggle">
-        <span data-localise="__MSG_viewImage__">View Image: </span>
-        <input type="text" id="button-text-view-image" />
-        <br>
-        <br>
-        <span data-localise="__MSG_searchImage__">Search by Image: </span>
-        <input type="text" id="button-text-search-by-image" />
+        <div>
+            <span data-localise="__MSG_viewImage__">View Image: </span>
+            <input type="text" id="button-text-view-image" />
+        </div>
+        <div>
+            <span data-localise="__MSG_searchImage__">Search by Image: </span>
+            <input type="text" id="button-text-search-by-image" />
+        </div>
     </div>
 
-    <br>
     <button type="button" id="reset-options" data-localise="__MSG_resetButton__">Reset</button>
 
 


### PR DESCRIPTION
- Hide disabled `<input>` instead of using `pointer-events: none`
  Keyboard and other means can still navigate to the inputs, which looks like a bug.
- Drop `<br>` and add appropriate paddings (opinionated)
  This is not perfect on Chrome because when toggling the inputs the options dialog will jump because of height change. Firefox will stretch the page to adjust to the change but Chrome seems to need special layouts to achieve that (need to drop `float`, but when I use flexbox the problem reappeared so I gave up 😞)