### PR TITLE
Adds general Portuguese support and also specific pt_PT locale

### DIFF
--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,0 +1,54 @@
+{
+    "appName": {
+        "message": "Ver Imagem",
+        "description": "Nome da extensão, como apresentado na web store."
+    },
+    "appDesc": {
+        "message": "Reintroduz o botão \"Ver imagem\" e o link \"Pesquisar por imagem\" do Google Imagens.",
+        "description": "A descrição da extensão, como apresentada na web store."
+    },
+    "searchImage": {
+        "message": "Pesquisar por imagem",
+        "description": "Botão leva à página \"Pesquisar por imagem\" do Google."
+    },
+    "viewImage": {
+        "message": "Ver imagem",
+        "description": "Botão para visualizar a imagem."
+    },
+    "settingsToggle_NewTab_viewImage": {
+        "message": "Abrir \"Ver imagem\" num novo separador:",
+        "description": "Opção que permite que as imagens sejam abertas num novo separador."
+   },
+    "settingsToggle_NewTab_searchByImage": {
+        "message": "Abrir \"Pesquisar por imagem\" num novo separador:",
+        "description": "Opção que permite que a página \"Pesquisar por imagem\" seja aberta num novo separador."
+    },
+    "settingsToggle_globeIcon": {
+        "message": "Ver ícone do Globo no botão \"Ver imagem\":",
+        "description": "Opção que permite que o ícone do globo seja apresentado no botão \"Ver imagem\"."
+    },
+    "settingsToggle_subjectCopyright": {
+        "message": "Ocultar aviso \"As imagens podem estar sujeitas a direitos de autor\":",
+        "description": "Opção que permite ocultar o aviso de direitos de autor na página de resultados de imagens."
+    },
+    "settingsToggle_noReferrer": {
+        "message": "Ocultar referenciador do site ao clicar em \"Ver imagem\":",
+        "description": "Opção que alterna a inclusão de rel='noreferrer' no botão \"Ver imagem\"."
+    },
+    "settingsToggle_buttonText": {
+        "message": "Definir texto do botão manualmente:",
+        "description": "Opção que permite definir manualmente o texto dos botões em vez da tradução."
+    },
+    "resetButton": {
+        "message": "Restaurar",
+        "description": "Texto apresentado no botão para reiniciar as prédefinições."
+    },
+    "optionsButton": {
+        "message": "Opções",
+        "description": "Texto apresentado no link para o botão de opções."
+    },
+    "donatePayPal": {
+        "message": " Doar via PayPal",
+        "description": "Texto usado no botão de doação."
+    }
+}

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -1,0 +1,54 @@
+{
+    "appName": {
+        "message": "Ver Imagem",
+        "description": "Nome da extensão, como apresentado na web store."
+    },
+    "appDesc": {
+        "message": "Reintroduz o botão \"Ver imagem\" e o link \"Pesquisar por imagem\" do Google Imagens.",
+        "description": "A descrição da extensão, como apresentada na web store."
+    },
+    "searchImage": {
+        "message": "Pesquisar por imagem",
+        "description": "Botão leva à página \"Pesquisar por imagem\" do Google."
+    },
+    "viewImage": {
+        "message": "Ver imagem",
+        "description": "Botão para visualizar a imagem."
+    },
+    "settingsToggle_NewTab_viewImage": {
+        "message": "Abrir \"Ver imagem\" num novo separador:",
+        "description": "Opção que permite que as imagens sejam abertas num novo separador."
+   },
+    "settingsToggle_NewTab_searchByImage": {
+        "message": "Abrir \"Pesquisar por imagem\" num novo separador:",
+        "description": "Opção que permite que a página \"Pesquisar por imagem\" seja aberta num novo separador."
+    },
+    "settingsToggle_globeIcon": {
+        "message": "Ver ícone do Globo no botão \"Ver imagem\":",
+        "description": "Opção que permite que o ícone do globo seja apresentado no botão \"Ver imagem\"."
+    },
+    "settingsToggle_subjectCopyright": {
+        "message": "Ocultar aviso \"As imagens podem estar sujeitas a direitos de autor\":",
+        "description": "Opção que permite ocultar o aviso de direitos de autor na página de resultados de imagens."
+    },
+    "settingsToggle_noReferrer": {
+        "message": "Ocultar referenciador do site ao clicar em \"Ver imagem\":",
+        "description": "Opção que alterna a inclusão de rel='noreferrer' no botão \"Ver imagem\"."
+    },
+    "settingsToggle_buttonText": {
+        "message": "Definir texto do botão manualmente:",
+        "description": "Opção que permite definir manualmente o texto dos botões em vez da tradução."
+    },
+    "resetButton": {
+        "message": "Restaurar",
+        "description": "Texto apresentado no botão para reiniciar as prédefinições."
+    },
+    "optionsButton": {
+        "message": "Opções",
+        "description": "Texto apresentado no link para o botão de opções."
+    },
+    "donatePayPal": {
+        "message": " Doar via PayPal",
+        "description": "Texto usado no botão de doação."
+    }
+}


### PR DESCRIPTION
Currently, Brazilian Portuguese is the only existing Portuguese locale.
This pull request adds European Portuguese (Portugal) localization and also uses it as base for other unsupported Portuguese locales using the generic 'pt' ISO code as fallback.