### PR TITLE
Upgrade to Manifest V3, reduce errors, tune permissions

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -26,19 +26,21 @@ chrome.storage.sync.get('defaultOptions', function () {
 });
 
 
-chrome.storage.sync.get(['options', 'defaultOptions'], function (storage) {
-    const options = Object.assign(storage.defaultOptions, storage.options);
+chrome.runtime.onInstalled.addListener(() => {
+    chrome.storage.sync.get(['options', 'defaultOptions'], function (storage) {
+        const options = Object.assign(storage.defaultOptions, storage.options);
 
-    // Setup "Search by image" context menu item
-    if (options['context-menu-search-by-image']) {
-        chrome.contextMenus.create(
-            {
-                'id': 'ViewImage-SearchByImage',
-                'title': toI18n('__MSG_searchImage__'),
-                'contexts': ['image'],
-            }
-        );
-    }
+        // Setup "Search by image" context menu item
+        if (options['context-menu-search-by-image']) {
+            chrome.contextMenus.create(
+                {
+                    'id': 'ViewImage-SearchByImage',
+                    'title': toI18n('__MSG_searchImage__'),
+                    'contexts': ['image'],
+                }
+            );
+        }
+    });
 });
 
 chrome.contextMenus.onClicked.addListener(

--- a/js/background.js
+++ b/js/background.js
@@ -50,23 +50,17 @@ chrome.contextMenus.onClicked.addListener(
             console.log('ViewImage: Search By Image context menu item clicked.', info, tab);
 
         if (info.menuItemId === 'ViewImage-SearchByImage') {
-            chrome.permissions.request({
-                permissions: ['tabs'],
-                origins: [tab.url],
-            }, (granted) => {
-                if (granted) {
-                    chrome.storage.sync.get(['options', 'defaultOptions'], function (storage) {
-                        const options = Object.assign(storage.defaultOptions, storage.options);
+            chrome.storage.sync.get(['options', 'defaultOptions'], function (storage) {
+                const options = Object.assign(storage.defaultOptions, storage.options);
 
-                        if (options['context-menu-search-by-image-new-tab']) {
-                            chrome.tabs.executeScript(tab.id, {
-                                code: `window.open('http://www.google.com/searchbyimage?image_url=${encodeURIComponent(info.srcUrl)}', '_blank').focus();`
-                            });
-                        } else {
-                            chrome.tabs.executeScript(tab.id, {
-                                code: `window.location.href = 'http://www.google.com/searchbyimage?image_url=${encodeURIComponent(info.srcUrl)}';`
-                            });
-                        }
+                if (options['context-menu-search-by-image-new-tab']) {
+                    chrome.tabs.create({
+                        url: `http://www.google.com/searchbyimage?image_url=${encodeURIComponent(info.srcUrl)}`,
+                        index: tab.index + 1
+                    });
+                } else {
+                    chrome.tabs.update(tab.id, {
+                        url: `http://www.google.com/searchbyimage?image_url=${encodeURIComponent(info.srcUrl)}`
                     });
                 }
             });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "__MSG_appName__",
-    "version": "3.6.4",
+    "version": "4.0.0",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
     "icons": {
@@ -12,7 +12,7 @@
         "16": "icon/16.png"
     },
     "author": "Joshua Butt",
-    "browser_action": {
+    "action": {
         "default_icon": "icon/48.png",
         "default_popup": "html/popup.html"
     },
@@ -22,21 +22,15 @@
         }
     },
     "permissions": [
+        "activeTab",
         "contextMenus",
         "storage"
-    ],
-    "optional_permissions": [
-        "tabs",
-        "*://*/*"
     ],
     "options_ui": {
         "page": "html/options.html"
     },
     "background": {
-        "persistent": false,
-        "scripts": [
-            "js/background.js"
-        ]
+        "service_worker": "js/background.js"
     },
     "content_scripts": [
         {


### PR DESCRIPTION
Upgrade manifest v3:
Renamed entries in manifest

Reduce errors:
Add onInstalled listener, which fixes `Unchecked runtime.lastError: Cannot create item with duplicate id ViewImage-SearchByImage`

Tune permissions:
Replace `tabs` with `activeTab` permission, which do longer prompts permission every time