### PR TITLE
Add `homepage_url`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
     "name": "__MSG_appName__",
     "version": "3.6.5",
     "description": "__MSG_appDesc__",
+    "homepage_url": "https://github.com/bijij/ViewImage",
     "default_locale": "en",
     "icons": {
         "128": "icon/128.png",


### PR DESCRIPTION
This (hopefully) adds a homepage button on e.g. the Chrome Web Store which makes finding the repo easier as the link in the description isn't clickable.